### PR TITLE
test: add unit tests for RIP-7560 transactions

### DIFF
--- a/tests/rip7560/process_test.go
+++ b/tests/rip7560/process_test.go
@@ -1,0 +1,115 @@
+// attempt to test Process, and how 7560 transaction affect normal TXs
+package rip7560
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/tests"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"testing"
+)
+
+/**
+Test that "Process" of 7560 transactions doesn't alter legacy transaction processing.
+the idea:
+1. Run "Process" with a set of transactions L1 [AA1..AAn] L2
+2. Run "Process" just with the lagacy transactions L1,L2
+3. if AA transactions revert validation - make sure the legacy processing is intact.
+4. if AA transactions are executed, make sure the needed state changes of the legacy transactions is intact
+*/
+
+const addr1 = "f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+const privKey1 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+const addr2 = "70997970C51812dc3A010C7d01b50e0d17dc79C8"
+const privKey2 = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+// initial minimal test that a valid AATX can be processed in a block
+func TestProcess1(t *testing.T) {
+
+	Sender := common.HexToAddress(DEFAULT_SENDER)
+	runProcess(newTestContextBuilder(t).
+		withAccount(addr1, 100000000000000).
+		withCode(DEFAULT_SENDER, createAccountCode(), 1000000000000000000).
+		build(), []*types.Rip7560AccountAbstractionTx{
+		{
+			Sender:        &Sender,
+			ValidationGas: uint64(1000000000),
+			GasFeeCap:     big.NewInt(1000000000),
+			Data:          []byte{1, 2, 3},
+		},
+	})
+}
+
+// run a set of AA transactions, with a legacy TXs before and after.
+func runProcess(t *testContext, aatxs []*types.Rip7560AccountAbstractionTx) error {
+	//t.chainConfig = params.OptimismTestConfig
+	var db ethdb.Database = rawdb.NewMemoryDatabase()
+	var state = tests.MakePreState(db, t.genesisAlloc, false, rawdb.HashScheme)
+	defer state.Close()
+	cacheConfig := &core.CacheConfig{}
+	chainOverrides := core.ChainOverrides{}
+	log.Info("isOptimismEnabled", "isOptimismEnabled", cacheConfig)
+
+	engine := beacon.New(ethash.NewFaker())
+	lookupLimit := uint64(0)
+	blockchain, err := core.NewBlockChain(db, cacheConfig, t.genesis, &chainOverrides, engine,
+		vm.Config{}, shouldPreserve, &lookupLimit)
+	if err != nil {
+		t.t.Fatalf("NewBlockChain failed: %v", err)
+	}
+
+	signer := types.MakeSigner(blockchain.Config(), new(big.Int), 0)
+	key1, _ := crypto.HexToECDSA(privKey1)
+	if crypto.PubkeyToAddress(key1.PublicKey) != common.HexToAddress(addr1) {
+		t.t.Fatalf("sanity: addr1 doesn't match privKey1: should be %s", crypto.PubkeyToAddress(key1.PublicKey))
+	}
+	//addr1 := crypto.PubkeyToAddress(key1.PublicKey)
+
+	key2, _ := crypto.HexToECDSA(privKey2)
+	addr2 := crypto.PubkeyToAddress(key2.PublicKey)
+
+	tx1, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		Nonce:     0,
+		GasFeeCap: big.NewInt(1000000000),
+		Value:     big.NewInt(1),
+		Gas:       30000,
+		To:        &addr2,
+	}), signer, key1)
+
+	tx3, _ := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		Nonce:     1,
+		GasFeeCap: big.NewInt(1000000000),
+		Value:     big.NewInt(2),
+		Gas:       30000,
+		To:        &addr2,
+	}), signer, key1)
+
+	txs := []*types.Transaction{tx1}
+	for _, aatx := range aatxs {
+		txs = append(txs, types.NewTx(aatx))
+	}
+	txs = append(txs, tx3)
+
+	b := types.NewBlock(blockchain.CurrentBlock(), txs, nil, nil, trie.NewStackTrie(nil))
+	_, _, _, err = blockchain.Processor().Process(b, state.StateDB, vm.Config{})
+	if err != nil {
+		return err
+	}
+	assert.Equal(t.t, "0x3", state.StateDB.GetBalance(addr2).Hex(), "failed to process pre/post legacy transactions")
+	return nil
+}
+
+func shouldPreserve(*types.Header) bool {
+	return false
+}

--- a/tests/rip7560/rip7560TestUtils.go
+++ b/tests/rip7560/rip7560TestUtils.go
@@ -1,0 +1,150 @@
+package rip7560
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/status-im/keycard-go/hexutils"
+	"math/big"
+	"testing"
+)
+
+const DEFAULT_SENDER = "0x1111111111222222222233333333334444444444"
+
+type testContext struct {
+	genesisAlloc types.GenesisAlloc
+	t            *testing.T
+	chainContext *ethapi.ChainContext
+	chainConfig  *params.ChainConfig
+	gaspool      *core.GasPool
+	genesis      *core.Genesis
+	genesisBlock *types.Block
+}
+
+func newTestContext(t *testing.T) *testContext {
+	return newTestContextBuilder(t).build()
+}
+
+type testContextBuilder struct {
+	t            *testing.T
+	chainConfig  *params.ChainConfig
+	genesisAlloc types.GenesisAlloc
+}
+
+func newTestContextBuilder(t *testing.T) *testContextBuilder {
+	genesisAlloc := types.GenesisAlloc{}
+
+	chainConfig := params.AllDevChainProtocolChanges
+	// probably bug in geth..
+	chainConfig.PragueTime = chainConfig.CancunTime
+	// set the chain config for Optimism
+	chainConfig.Optimism = params.OptimismTestConfig.Optimism
+
+	return &testContextBuilder{
+		t:            t,
+		chainConfig:  chainConfig,
+		genesisAlloc: genesisAlloc,
+	}
+}
+
+func (tb *testContextBuilder) build() *testContext {
+	genesis := &core.Genesis{
+		Config: params.AllDevChainProtocolChanges,
+		Alloc:  tb.genesisAlloc,
+	}
+	genesisBlock := genesis.ToBlock()
+	gaspool := new(core.GasPool).AddGas(genesisBlock.GasLimit())
+
+	//TODO: fill some mock backend...
+	var backend ethapi.Backend
+
+	return &testContext{
+		t:            tb.t,
+		genesisAlloc: tb.genesisAlloc,
+		chainContext: ethapi.NewChainContext(context.TODO(), backend),
+		chainConfig:  tb.chainConfig,
+		genesis:      genesis,
+		genesisBlock: genesisBlock,
+		gaspool:      gaspool,
+	}
+}
+
+// add EOA account with balance
+func (tt *testContextBuilder) withAccount(addr string, balance int64) *testContextBuilder {
+	tt.genesisAlloc[common.HexToAddress(addr)] = types.Account{Balance: big.NewInt(balance)}
+	return tt
+}
+
+func (tt *testContextBuilder) withCode(addr string, code []byte, balance int64) *testContextBuilder {
+	if len(code) == 0 {
+		tt.genesisAlloc[common.HexToAddress(addr)] = types.Account{
+			Balance: big.NewInt(balance),
+		}
+	} else {
+		tt.genesisAlloc[common.HexToAddress(addr)] = types.Account{
+			Code:    code,
+			Balance: big.NewInt(balance),
+		}
+	}
+	return tt
+}
+
+// generate the code to return the given byte array (up to 32 bytes)
+func returnData(data []byte) []byte {
+	//couldn't get geth to support PUSH0 ...
+	datalen := len(data)
+	if datalen == 0 {
+		data = []byte{0}
+	}
+	if datalen > 32 {
+		panic(fmt.Errorf("data length is too big %v", data))
+	}
+
+	PUSHn := byte(int(vm.PUSH0) + datalen)
+	ret := createCode(PUSHn, data, vm.PUSH1, 0, vm.MSTORE, vm.PUSH1, 32, vm.PUSH1, 0, vm.RETURN)
+	return ret
+}
+
+// create bytecode for account
+func createAccountCode() []byte {
+	magic := big.NewInt(0xbf45c166)
+	magic.Lsh(magic, 256-32)
+
+	return returnData(magic.Bytes())
+}
+
+// create EVM code from OpCode, byte and []bytes
+func createCode(items ...interface{}) []byte {
+	var buffer bytes.Buffer
+
+	for _, item := range items {
+		switch v := item.(type) {
+		case string:
+			buffer.Write(hexutils.HexToBytes(v))
+		case vm.OpCode:
+			buffer.WriteByte(byte(v))
+		case byte:
+			buffer.WriteByte(v)
+		case []byte:
+			buffer.Write(v)
+		case int8:
+			buffer.WriteByte(byte(v))
+		case int:
+			if v >= 256 {
+				panic(fmt.Errorf("int defaults to int8 (byte). int16, etc: %v", v))
+			}
+			buffer.WriteByte(byte(v))
+		default:
+			// should be a compile-time error...
+			panic(fmt.Errorf("unsupported type: %T", v))
+		}
+	}
+
+	return buffer.Bytes()
+}

--- a/tests/rip7560/validation_test.go
+++ b/tests/rip7560/validation_test.go
@@ -1,0 +1,87 @@
+package rip7560
+
+import (
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/tests"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestValidation_OOG(t *testing.T) {
+	magic := big.NewInt(0xbf45c166)
+	magic.Lsh(magic, 256-32)
+
+	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1),
+		GasFeeCap:     big.NewInt(1000000000),
+	}, "out of gas")
+}
+
+func TestValidation_ok(t *testing.T) {
+	magic := big.NewInt(0xbf45c166)
+	magic.Lsh(magic, 256-32)
+
+	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000000),
+		GasFeeCap:     big.NewInt(1000000000),
+	}, "")
+}
+
+func TestValidation_account_revert(t *testing.T) {
+	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		createCode(vm.PUSH1, 0, vm.DUP1, vm.REVERT), 0), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000000),
+		GasFeeCap:     big.NewInt(1000000000),
+	}, "execution reverted")
+}
+
+func TestValidation_account_no_return_value(t *testing.T) {
+	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER, []byte{
+		byte(vm.PUSH1), 0, byte(vm.DUP1), byte(vm.RETURN),
+	}, 0), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000000),
+		GasFeeCap:     big.NewInt(1000000000),
+	}, "invalid account return data length")
+}
+
+func TestValidation_account_wrong_return_value(t *testing.T) {
+	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		returnData(createCode(1)),
+		0), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000000),
+		GasFeeCap:     big.NewInt(1000000000),
+	}, "account did not return correct MAGIC_VALUE")
+}
+
+func validatePhase(tb *testContextBuilder, aatx types.Rip7560AccountAbstractionTx, expectedErr string) {
+	t := tb.build()
+	if aatx.Sender == nil {
+		//pre-deployed sender account
+		Sender := common.HexToAddress(DEFAULT_SENDER)
+		aatx.Sender = &Sender
+	}
+	tx := types.NewTx(&aatx)
+
+	var state = tests.MakePreState(rawdb.NewMemoryDatabase(), t.genesisAlloc, false, rawdb.HashScheme)
+	defer state.Close()
+
+	_, err := core.ApplyRip7560ValidationPhases(t.chainConfig, t.chainContext, &common.Address{}, t.gaspool, state.StateDB, t.genesisBlock.Header(), tx, vm.Config{})
+	// err string or empty if nil
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	assert.Equal(t.t, expectedErr, errStr)
+}
+
+//test failure on non-rip7560
+
+//IntrinsicGas: for validation frame, should return the max possible gas.
+// - execution should be "free" (and refund the excess)
+// geth increment nonce before "call" our validation frame. (in ApplyMessage)


### PR DESCRIPTION
# Description

Add unit tests for RIP-7560 transactions, which is from eth-infinitism working branch. Added `Optimism` config to avoid errors when calculating `l1Cost`.
