### PR TITLE
Docs improvements

### DIFF
--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -32,7 +32,7 @@ type Error struct {
 
 	// Sig contains the string signature according to the ABI spec.
 	// e.g. error foo(uint32 a, int b) = "foo(uint32,int256)"
-	// Please note that "int" is substitute for its canonical representation "int256"
+	// Please note that "int" is substituted for its canonical representation "int256"
 	Sig string
 
 	// ID returns the canonical representation of the error's signature used by the

--- a/accounts/abi/error_handling.go
+++ b/accounts/abi/error_handling.go
@@ -43,7 +43,7 @@ func formatSliceString(kind reflect.Kind, sliceSize int) string {
 	return fmt.Sprintf("[%d]%v", sliceSize, kind)
 }
 
-// sliceTypeCheck checks that the given slice can by assigned to the reflection
+// sliceTypeCheck checks that the given slice can be assigned to the reflection
 // type in t.
 func sliceTypeCheck(t Type, val reflect.Value) error {
 	if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {

--- a/accounts/abi/event.go
+++ b/accounts/abi/event.go
@@ -47,7 +47,7 @@ type Event struct {
 
 	// Sig contains the string signature according to the ABI spec.
 	// e.g.	 event foo(uint32 a, int b) = "foo(uint32,int256)"
-	// Please note that "int" is substitute for its canonical representation "int256"
+	// Please note that "int" is substituted for its canonical representation "int256"
 	Sig string
 
 	// ID returns the canonical representation of the event's signature used by the

--- a/accounts/abi/method.go
+++ b/accounts/abi/method.go
@@ -48,7 +48,7 @@ const (
 // from the storage and therefore requires no Tx to be sent to the
 // network. A method such as `Transact` does require a Tx and thus will
 // be flagged `false`.
-// Input specifies the required input parameters for this gives method.
+// Input specifies the required input parameters for this given method.
 type Method struct {
 	// Name is the method name used for internal representation. It's derived from
 	// the raw name and a suffix will be added in the case of a function overload.

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -220,7 +220,7 @@ func forTupleUnpack(t Type, output []byte) (interface{}, error) {
 }
 
 // toGoType parses the output bytes and recursively assigns the value of these bytes
-// into a go type with accordance with the ABI spec.
+// into a go type in accordance with the ABI spec.
 func toGoType(index int, t Type, output []byte) (interface{}, error) {
 	if index+32 > len(output) {
 		return nil, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), index+32)


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.