### PR TITLE
fix: estimateRip7560TransactionGas with no paymaster

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -665,7 +665,7 @@ func (tx *Transaction) Hash() common.Hash {
 		h = rlpHash(tx.inner)
 	} else if tx.Type() == Rip7560BundleHeaderType {
 		rlpHash := rlpHash(tx.Rip7560BundleHeaderTransactionData())
-		h = crypto.Keccak256Hash(append([]byte{Rip7560Type, ScaTransactionSubtype}, rlpHash[:]...))
+		h = crypto.Keccak256Hash(append([]byte{Rip7560BundleHeaderType, ScaTransactionSubtype}, rlpHash[:]...))
 	} else {
 		h = prefixedRlpHash(tx.Type(), tx.inner)
 	}

--- a/core/types/transaction_signing_rip7560.go
+++ b/core/types/transaction_signing_rip7560.go
@@ -29,19 +29,18 @@ func (s rip7560Signer) Hash(tx *Transaction) common.Hash {
 		tx.Type(),
 		[]interface{}{
 			s.chainId,
+			aatx.BigNonce,
+			aatx.Sender,
+			aatx.DeployerData,
+			aatx.PaymasterData,
+			tx.Data(),
+			aatx.BuilderFee,
 			tx.GasTipCap(),
 			tx.GasFeeCap(),
-			tx.Gas(),
-			//tx.To(),
-			tx.Data(),
-			tx.AccessList(),
-
-			aatx.Sender,
-			aatx.PaymasterData,
-			aatx.DeployerData,
-			aatx.BuilderFee,
 			aatx.ValidationGas,
 			aatx.PaymasterGas,
-			aatx.BigNonce,
+			aatx.PostOpGas,
+			tx.Gas(),
+			tx.AccessList(),
 		})
 }


### PR DESCRIPTION
# Description

There was an edge case at estimateRip7560TransactionGas that if there's no paymaster data given the method crashes. Handled that in this PR.

Also included the missing commit of fix at hash calculation.