### PR TITLE
modify gas logic for rip 7560

### DIFF
--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -85,12 +85,14 @@ func handleRip7560Transactions(transactions []*types.Transaction, index int, sta
 		statedb.SetTxContext(tx.Hash(), len(validatedTransactions))
 		payment, prepaidGas, err := BuyGasRip7560Transaction(chainConfig, gp, header, tx, statedb)
 		if err != nil {
+			log.Warn("Failed to BuyGasRip7560Transaction", "err", err)
 			// TODO : do we have to drop bundle?
 			continue
 		}
 		var vpr *ValidationPhaseResult
 		vpr, err = ApplyRip7560ValidationPhases(chainConfig, bc, coinbase, gp, statedb, header, tx, cfg)
 		if err != nil {
+			log.Warn("Failed to ApplyRip7560ValidationPhases", "err", err)
 			// If an error occurs in the validation phase, invalidate the transaction
 			statedb.RevertToSnapshot(snapshot)
 			gp.SetGas(prevGas)

--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -239,7 +239,8 @@ func ApplyRip7560ValidationPhases(chainConfig *params.ChainConfig, bc ChainConte
 		} else if deployedAddr != *tx.Rip7560TransactionData().Sender {
 			return nil, errors.New("deployed address mismatch - invalid transaction")
 		}
-		deploymentUsedGas = resultDeployer.UsedGas
+		// TODO : would be handled inside IntrinsicGas
+		deploymentUsedGas = resultDeployer.UsedGas + params.TxGasContractCreation
 	}
 
 	/*** Account Validation Frame ***/
@@ -366,7 +367,7 @@ func ApplyRip7560ExecutionPhase(config *params.ChainConfig, vpr *ValidationPhase
 	// calculation for intrinsicGas
 	// TODO: integrated with code in state_transition
 	rules := evm.ChainConfig().Rules(evm.Context.BlockNumber, evm.Context.Random != nil, evm.Context.Time)
-	intrGas, err := IntrinsicGas(vpr.Tx.Data(), vpr.Tx.AccessList(), false, rules.IsHomestead, rules.IsIstanbul, rules.IsShanghai, false)
+	intrGas, err := IntrinsicGasWithOption(vpr.Tx.Data(), vpr.Tx.AccessList(), false, rules.IsHomestead, rules.IsIstanbul, rules.IsShanghai, true, false)
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -121,6 +121,27 @@ func (args *TransactionArgs) paymasterData() []byte {
 	return nil
 }
 
+func (args *TransactionArgs) paymasterGas() uint64 {
+	if args.PaymasterGas != nil {
+		return uint64(*args.PaymasterGas)
+	}
+	return 0
+}
+
+func (args *TransactionArgs) validationGas() uint64 {
+	if args.ValidationGas != nil {
+		return uint64(*args.ValidationGas)
+	}
+	return 0
+}
+
+func (args *TransactionArgs) postOpGas() uint64 {
+	if args.PostOpGas != nil {
+		return uint64(*args.PostOpGas)
+	}
+	return 0
+}
+
 func (args *TransactionArgs) deployerData() []byte {
 	if args.DeployerData != nil {
 		return *args.DeployerData
@@ -513,9 +534,9 @@ func (args *TransactionArgs) ToTransaction() *types.Transaction {
 			PaymasterData: args.paymasterData(),
 			DeployerData:  args.deployerData(),
 			BuilderFee:    (*big.Int)(args.BuilderFee),
-			ValidationGas: uint64(*args.ValidationGas),
-			PaymasterGas:  uint64(*args.PaymasterGas),
-			PostOpGas:     uint64(*args.PostOpGas),
+			ValidationGas: args.validationGas(),
+			PaymasterGas:  args.paymasterGas(),
+			PostOpGas:     args.postOpGas(),
 			// RIP-7712 parameter
 			BigNonce: (*big.Int)(args.BigNonce),
 		}


### PR DESCRIPTION
# Description

Modify gas logic for rip 7560.
- Calculating data gas cost without base gas cost.
- Calculating deployment gas costs when deploying contracts.
