### PR TITLE
fix: errors with packing and logging

### DIFF
--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -492,7 +492,7 @@ func prepareAccountValidationMessage(baseTx *types.Transaction, chainConfig *par
 		return nil, err
 	}
 	txAbiEncoding, err := tx.AbiEncode()
-	validateTransactionData, err := validateTransactionAbi.Pack("validateTransaction", big.NewInt(0), signingHash, txAbiEncoding)
+	validateTransactionData, err := validateTransactionAbi.Pack("validateTransaction", big.NewInt(1), signingHash, txAbiEncoding)
 	return &Message{
 		From:              chainConfig.EntryPointAddress,
 		To:                tx.Sender,
@@ -520,7 +520,7 @@ func preparePaymasterValidationMessage(baseTx *types.Transaction, config *params
 
 	validateTransactionAbi, err := abi.JSON(strings.NewReader(jsondata))
 	txAbiEncoding, err := tx.AbiEncode()
-	data, err := validateTransactionAbi.Pack("validatePaymasterTransaction", big.NewInt(0), signingHash, txAbiEncoding)
+	data, err := validateTransactionAbi.Pack("validatePaymasterTransaction", big.NewInt(1), signingHash, txAbiEncoding)
 
 	if err != nil {
 		return nil, err

--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -386,8 +386,8 @@ func ApplyRip7560ExecutionPhase(config *params.ChainConfig, vpr *ValidationPhase
 	if paymasterPostOpResult != nil {
 		cumulativeGasUsed +=
 			paymasterPostOpResult.UsedGas
+		log.Info("[RIP-7560] Execution gas info", "paymasterPostOpResult.UsedGas", paymasterPostOpResult.UsedGas)
 	}
-	log.Info("[RIP-7560] Execution gas info", "paymasterPostOpResult.UsedGas", paymasterPostOpResult.UsedGas)
 
 	// calculation for intrinsicGas
 	// TODO: integrated with code in state_transition

--- a/core/types/tx_rip7560.go
+++ b/core/types/tx_rip7560.go
@@ -170,7 +170,7 @@ func (tx *Rip7560AccountAbstractionTx) AbiEncode() ([]byte, error) {
 		{Name: "nonce", Type: "uint256"},
 		{Name: "validationGasLimit", Type: "uint256"},
 		{Name: "paymasterGasLimit", Type: "uint256"},
-		{Name: "postOpGas", Type: "uint256"},
+		{Name: "postOpGasLimit", Type: "uint256"},
 		{Name: "callGasLimit", Type: "uint256"},
 		{Name: "maxFeePerGas", Type: "uint256"},
 		{Name: "maxPriorityFeePerGas", Type: "uint256"},


### PR DESCRIPTION
# Description

Fixed 2 errors.
1. Fixed the position of the paymasterPostOpResult logging message.
2. Fixed the pack variable name from `postOpGas` to `postOpGasLimit` - it generated an error at packing and the `transaction` data returned `nil`.
