### PR TITLE
feat: move signature calculation position

### DIFF
--- a/eth/tracers/api_tracing_rip7560.go
+++ b/eth/tracers/api_tracing_rip7560.go
@@ -122,7 +122,10 @@ func (api *Rip7560API) traceTx(ctx context.Context, tx *types.Transaction, txctx
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
 	gp := new(core.GasPool).AddGas(10000000)
 
-	_, err = core.ApplyRip7560ValidationPhases(api.backend.ChainConfig(), api.chainContext(ctx), nil, gp, statedb, block.Header(), tx, vmenv.Config)
+	signer := types.MakeSigner(api.backend.ChainConfig(), block.Header().Number, block.Header().Time)
+	signingHash := signer.Hash(tx)
+
+	_, err = core.ApplyRip7560ValidationPhases(api.backend.ChainConfig(), api.chainContext(ctx), nil, gp, statedb, block.Header(), tx, vmenv.Config, signingHash)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}

--- a/internal/ethapi/rip7560api.go
+++ b/internal/ethapi/rip7560api.go
@@ -113,6 +113,9 @@ func doCallRip7560Validation(ctx context.Context, b Backend, args TransactionArg
 		GasPrice: tx.GasPrice(),
 	}
 	evm := vm.NewEVM(blockContext, txContext, state, chainConfig, vm.Config{NoBaseFee: true})
+
+	signer := types.MakeSigner(chainConfig, header.Number, header.Time)
+	signingHash := signer.Hash(tx)
 	// Wait for the context to be done and cancel the evm. Even if the
 	// EVM has finished, cancelling may be done (repeatedly)
 	go func() {
@@ -127,7 +130,7 @@ func doCallRip7560Validation(ctx context.Context, b Backend, args TransactionArg
 		return nil, err
 	}
 
-	result, err := core.ApplyRip7560ValidationPhases(chainConfig, bc, &header.Coinbase, gp, state, header, tx, evm.Config)
+	result, err := core.ApplyRip7560ValidationPhases(chainConfig, bc, &header.Coinbase, gp, state, header, tx, evm.Config, signingHash)
 	if err := state.Error(); err != nil {
 		return nil, err
 	}

--- a/tests/rip7560/validation_test.go
+++ b/tests/rip7560/validation_test.go
@@ -68,10 +68,13 @@ func validatePhase(tb *testContextBuilder, aatx types.Rip7560AccountAbstractionT
 	}
 	tx := types.NewTx(&aatx)
 
-	var state = tests.MakePreState(rawdb.NewMemoryDatabase(), t.genesisAlloc, false, rawdb.HashScheme)
+	var state, _, statedb = tests.MakePreState(rawdb.NewMemoryDatabase(), t.genesisAlloc, false, rawdb.HashScheme)
 	defer state.Close()
 
-	_, err := core.ApplyRip7560ValidationPhases(t.genesis.Config, t.chainContext, &common.Address{}, t.gaspool, state.StateDB, t.genesisBlock.Header(), tx, vm.Config{})
+	signer := types.MakeSigner(t.genesis.Config, t.genesisBlock.Header().Number, t.genesisBlock.Header().Time)
+	signingHash := signer.Hash(tx)
+
+	_, err := core.ApplyRip7560ValidationPhases(t.genesis.Config, t.chainContext, &common.Address{}, t.gaspool, statedb, t.genesisBlock.Header(), tx, vm.Config{}, signingHash)
 	// err string or empty if nil
 	errStr := ""
 	if err != nil {


### PR DESCRIPTION
# Description

Moved the position to calculate signature to outside of ApplyRip7560ValidationPhases function, to ensure the estimation of RIP7560 transaction is done well.