### PR TITLE
fix: issue with captureState handler crashed in RIP-7560 tracer

### DIFF
--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -243,6 +243,7 @@ func ApplyRip7560ValidationPhases(chainConfig *params.ChainConfig, bc ChainConte
 			return nil, err
 		}
 		deployedAddr := common.BytesToAddress(resultDeployer.ReturnData)
+		log.Info("[RIP-7560]", "deployedAddr", deployedAddr.Hex())
 		if resultDeployer.Failed() || statedb.GetCode(deployedAddr) == nil {
 			// TODO: bubble up the inner error message to the user, if possible
 			return nil, errors.New("account deployment failed - invalid transaction")
@@ -422,7 +423,10 @@ func ApplyRip7560ExecutionPhase(config *params.ChainConfig, vpr *ValidationPhase
 		statedb.AddBalance(params.OptimismL1FeeRecipient, amtU256)
 	}
 
-	log.Info("[RIP-7560] Execution gas info", "vpr.NonceValidationUsedGas", vpr.NonceValidationUsedGas, "vpr.ValidationUsedGas", vpr.ValidationUsedGas, "vpr.DeploymentUsedGas", vpr.DeploymentUsedGas, "vpr.PmValidationUsedGas", vpr.PmValidationUsedGas, "executionResult.UsedGas", executionResult.UsedGas, "paymasterPostOpResult.UsedGas", paymasterPostOpResult.UsedGas, "IntrinsicGas", intrGas, "gasPenalty", gasPenalty)
+	log.Info("[RIP-7560] Execution gas info", "vpr.NonceValidationUsedGas", vpr.NonceValidationUsedGas, "vpr.ValidationUsedGas", vpr.ValidationUsedGas, "vpr.DeploymentUsedGas", vpr.DeploymentUsedGas, "vpr.PmValidationUsedGas", vpr.PmValidationUsedGas, "executionResult.UsedGas", executionResult.UsedGas, "IntrinsicGas", intrGas, "gasPenalty", gasPenalty)
+	if paymasterPostOpResult != nil {
+		log.Info("[RIP-7560] Execution gas info", "paymasterPostOpResult.UsedGas", paymasterPostOpResult.UsedGas)
+	}
 	log.Info("[RIP-7560] Execution gas info", "cumulativeGasUsed", cumulativeGasUsed)
 
 	return executionResult, paymasterPostOpResult, cumulativeGasUsed, nil

--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -270,10 +270,6 @@ func executeRip7560Validation(ctx context.Context, tx *types.Transaction, opts *
 	// Gas Pool is set to half of the maximum possible gas to prevent overflow
 	vpr, err := core.ApplyRip7560ValidationPhases(opts.Config, opts.Chain, &opts.Header.Coinbase, new(core.GasPool).AddGas(math.MaxUint64/2), dirtyState, opts.Header, tx, evm.Config, signingHash)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	if err != nil {
 		if errors.Is(err, vm.ErrOutOfGas) {
 			return nil, nil, nil // Special case, raise gas limit
 		}


### PR DESCRIPTION
# Description

Fix issue with captureState handler crashed in RIP-7560 tracer.

- LOG: Fix data error
- REVERT, RETURN: Prevent length error
- KECCAK256: Fix slice logic 
