### PR TITLE
feat: prepare hardfork(ecotone, fjord)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -43,6 +43,9 @@ fi
   --metrics.addr=0.0.0.0 \
   --metrics.port=36060 \
   --miner.recommit=1s \
+  --override.canyon=0 \
+  --override.ecotone=1721026803 \
+  --override.fjord=1721026805 \
   --log.maxsize=100 \
   --log.rotate \
   --log.format=logfmt \


### PR DESCRIPTION
# Description

Prepare hardfork time.

- delta : 1721026801 (2024-07-15T07:00:01.000Z)
- ecotone: 1721026803 (block number : 429946)
- fjord : 1721026805 (block number : 429947)

This should be paired with the following in Rollup.config
"delta_time": 1721026801,
"ecotone_time": 1721026803,
"fjord_time": 1721026805,