### PR TITLE
test: update RIP-7560 unit tests

### DIFF
--- a/tests/rip7560/deployer_test.go
+++ b/tests/rip7560/deployer_test.go
@@ -1,0 +1,88 @@
+package rip7560
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"math/big"
+	"testing"
+)
+
+var DEPLOYER = common.HexToAddress("0xddddddddddeeeeeeeeeeddddddddddeeeeeeeeee")
+
+func TestValidationFailure_deployerRevert(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).
+		withCode(DEFAULT_SENDER, []byte{}, DEFAULT_BALANCE).
+		withCode(DEPLOYER.Hex(), revertWithData([]byte{}), 0),
+		types.Rip7560AccountAbstractionTx{
+			Deployer:      &DEPLOYER,
+			ValidationGas: 1000000,
+			GasFeeCap:     big.NewInt(1),
+		}, "account deployment failed: execution reverted")
+}
+
+func TestValidationFailure_deployerOOG(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).
+		withCode(DEFAULT_SENDER, []byte{}, DEFAULT_BALANCE).
+		withCode(DEPLOYER.Hex(), revertWithData([]byte{}), 0),
+		types.Rip7560AccountAbstractionTx{
+			Deployer:      &DEPLOYER,
+			ValidationGas: 1,
+			GasFeeCap:     big.NewInt(1),
+		}, "account deployment failed: out of gas")
+}
+
+func TestValidationFailure_senderNotDeployed(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).
+		withCode(DEFAULT_SENDER, []byte{}, DEFAULT_BALANCE).
+		withCode(DEPLOYER.Hex(), returnWithData([]byte{}), 0),
+		types.Rip7560AccountAbstractionTx{
+			Deployer:      &DEPLOYER,
+			ValidationGas: 1000000,
+			GasFeeCap:     big.NewInt(1),
+		}, "account deployment failed: sender not deployed")
+}
+
+func TestValidationFailure_senderAlreadyDeployed(t *testing.T) {
+	accountCode := revertWithData([]byte{})
+	deployerCode := create2(accountCode)
+	sender := create2_addr(DEPLOYER, accountCode)
+	handleValidation(newTestContextBuilder(t).
+		withCode(sender.Hex(), accountCode, DEFAULT_BALANCE).
+		withCode(DEPLOYER.Hex(), deployerCode, 0),
+		types.Rip7560AccountAbstractionTx{
+			Sender:        &sender,
+			Deployer:      &DEPLOYER,
+			ValidationGas: 1000000,
+			GasFeeCap:     big.NewInt(1),
+		}, "account deployment failed: sender already deployed")
+}
+
+func TestValidationFailure_senderReverts(t *testing.T) {
+	accountCode := revertWithData([]byte{})
+	deployerCode := createCode(create2(accountCode), returnWithData([]byte{}))
+	sender := create2_addr(DEPLOYER, accountCode)
+	handleValidation(newTestContextBuilder(t).
+		withCode(sender.Hex(), []byte{}, DEFAULT_BALANCE).
+		withCode(DEPLOYER.Hex(), deployerCode, 0),
+		types.Rip7560AccountAbstractionTx{
+			Sender:        &sender,
+			Deployer:      &DEPLOYER,
+			ValidationGas: 1000000,
+			GasFeeCap:     big.NewInt(1),
+		}, "execution reverted")
+}
+
+func TestValidation_deployer_ok(t *testing.T) {
+	accountCode := createAccountCode()
+	deployerCode := createCode(create2(accountCode), returnWithData([]byte{}))
+	sender := create2_addr(DEPLOYER, accountCode)
+	handleValidation(newTestContextBuilder(t).
+		withCode(sender.Hex(), []byte{}, DEFAULT_BALANCE).
+		withCode(DEPLOYER.Hex(), deployerCode, 0),
+		types.Rip7560AccountAbstractionTx{
+			Sender:        &sender,
+			Deployer:      &DEPLOYER,
+			ValidationGas: 1000000,
+			GasFeeCap:     big.NewInt(1),
+		}, "ok")
+}

--- a/tests/rip7560/paymaster_test.go
+++ b/tests/rip7560/paymaster_test.go
@@ -1,0 +1,111 @@
+package rip7560
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"math/big"
+	"testing"
+)
+
+var DEFAULT_PAYMASTER = common.HexToAddress("0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd")
+
+func TestPaymasterValidationFailure_nobalance(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), createCode(push(0), vm.DUP1, vm.REVERT), 1), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "insufficient funds for gas * price + value: address 0xaaAaaAAAAAbBbbbbBbBBCCCCcCCCcCdddDDDdddd have 1 want 1015000")
+}
+
+func TestPaymasterValidationFailure_oog(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), createCode(push(0), vm.DUP1, vm.REVERT), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "out of gas")
+}
+func TestPaymasterValidationFailure_revert(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), createCode(push(0), vm.DUP1, vm.REVERT), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+		PaymasterGas:  1000000,
+	}, "execution reverted")
+}
+
+func TestPaymasterValidationFailure_unparseable_return_value(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), createAccountCode(), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		PaymasterGas:  1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "paymaster return data: too short")
+}
+
+func TestPaymasterValidationFailure_wrong_magic(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), returnWithData(paymasterReturnValue(1, 2, 3, []byte{})), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		PaymasterGas:  1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "paymaster did not return correct MAGIC_VALUE")
+}
+
+func TestPaymasterValidationFailure_contextTooLarge(t *testing.T) {
+	//paymaster returning huge context.
+	// first word is magic return value
+	// 2nd word is offset (fixed 64)
+	// 3rd word is length of context (max+1)
+	// then we return the total length of above (context itself is uninitialized string of max+1 zeroes)
+	pmCode := createCode(
+		//vm.PUSH1, 1, vm.PUSH1, 0, vm.RETURN,
+		copyToMemory(core.PackValidationData(core.MAGIC_VALUE_PAYMASTER, 0, 0), 0),
+		copyToMemory(asBytes32(64), 32),
+		copyToMemory(asBytes32(core.PAYMASTER_MAX_CONTEXT_SIZE+1), 64),
+		push(core.PAYMASTER_MAX_CONTEXT_SIZE+96+1), push(0), vm.RETURN)
+
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), pmCode, DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		PaymasterGas:  1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "paymaster return data: context too large")
+}
+
+func TestPaymasterValidationFailure_validAfter(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), returnWithData(paymasterReturnValue(core.MAGIC_VALUE_PAYMASTER, 300, 200, []byte{})), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		PaymasterGas:  1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "RIP-7560 transaction validity not reached yet")
+}
+
+func TestPaymasterValidationFailure_validUntil(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), returnWithData(paymasterReturnValue(core.MAGIC_VALUE_PAYMASTER, 1, 0, []byte{})), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		PaymasterGas:  1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "RIP-7560 transaction validity expired")
+}
+
+func TestPaymasterValidation_ok(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0).
+		withCode(DEFAULT_PAYMASTER.String(), returnWithData(paymasterReturnValue(core.MAGIC_VALUE_PAYMASTER, 0, 0, []byte{})), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: 1000000,
+		PaymasterGas:  1000000,
+		GasFeeCap:     big.NewInt(1),
+		Paymaster:     &DEFAULT_PAYMASTER,
+	}, "ok")
+}

--- a/tests/rip7560/process_test.go
+++ b/tests/rip7560/process_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/stretchr/testify/assert"
@@ -36,9 +35,8 @@ const privKey2 = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b7869
 
 // initial minimal test that a valid AATX can be processed in a block
 func TestProcess1(t *testing.T) {
-
 	Sender := common.HexToAddress(DEFAULT_SENDER)
-	runProcess(newTestContextBuilder(t).
+	err := runProcess(newTestContextBuilder(t).
 		withAccount(addr1, 100000000000000).
 		withCode(DEFAULT_SENDER, createAccountCode(), 1000000000000000000).
 		build(), []*types.Rip7560AccountAbstractionTx{
@@ -49,18 +47,17 @@ func TestProcess1(t *testing.T) {
 			Data:          []byte{1, 2, 3},
 		},
 	})
+	assert.NoError(t, err)
 }
 
 // run a set of AA transactions, with a legacy TXs before and after.
 func runProcess(t *testContext, aatxs []*types.Rip7560AccountAbstractionTx) error {
-	//t.chainConfig = params.OptimismTestConfig
 	var db ethdb.Database = rawdb.NewMemoryDatabase()
 	var state = tests.MakePreState(db, t.genesisAlloc, false, rawdb.HashScheme)
 	defer state.Close()
+
 	cacheConfig := &core.CacheConfig{}
 	chainOverrides := core.ChainOverrides{}
-	log.Info("isOptimismEnabled", "isOptimismEnabled", cacheConfig)
-
 	engine := beacon.New(ethash.NewFaker())
 	lookupLimit := uint64(0)
 	blockchain, err := core.NewBlockChain(db, cacheConfig, t.genesis, &chainOverrides, engine,

--- a/tests/rip7560/rip7560TestUtils.go
+++ b/tests/rip7560/rip7560TestUtils.go
@@ -8,13 +8,16 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/status-im/keycard-go/hexutils"
 	"math/big"
 	"testing"
 )
 
 const DEFAULT_SENDER = "0x1111111111222222222233333333334444444444"
+const DEFAULT_BALANCE = 1 << 62
 
 type testContext struct {
 	genesisAlloc types.GenesisAlloc
@@ -43,8 +46,35 @@ func newTestContextBuilder(t *testing.T) *testContextBuilder {
 	}
 }
 
+// return a contract code that will deploy the given code
+func create2_contract(deployedCode []byte) []byte {
+
+	return returnWithData(deployedCode)
+}
+
+// return the generated address when deploying the given code
+func create2_addr(deployer common.Address, deployedCode []byte) common.Address {
+
+	contractCode := create2_contract(deployedCode)
+	data := createCode(0xff, deployer.Bytes(), common.Hash{}, crypto.Keccak256(contractCode))
+	return common.BytesToAddress(crypto.Keccak256(data))
+}
+
+// generate code to call create2
+// note: parameter is the deployed code, not the full contract code
+// always use zero value and zero salt.
+func create2(deployedCode []byte) []byte {
+	contractCode := create2_contract(deployedCode)
+	return createCode(
+		copyToMemory(contractCode, 0),
+		push(0), push(len(contractCode)), push(0), push(0), vm.CREATE2,
+	)
+}
+
 func (tb *testContextBuilder) build() *testContext {
-	genesis := core.DeveloperGenesisBlock(10_000_000, &common.Address{})
+	genesis := core.DeveloperGenesisBlock(100_000_000, &common.Address{})
+	genesis.Timestamp = 100
+	genesis.Config.Optimism = &params.OptimismConfig{EIP1559Elasticity: 50, EIP1559Denominator: 10}
 	genesisBlock := genesis.ToBlock()
 	gaspool := new(core.GasPool).AddGas(genesisBlock.GasLimit())
 
@@ -66,7 +96,6 @@ func (tt *testContextBuilder) withAccount(addr string, balance int64) *testConte
 	tt.genesisAlloc[common.HexToAddress(addr)] = types.Account{Balance: big.NewInt(balance)}
 	return tt
 }
-
 func (tt *testContextBuilder) withCode(addr string, code []byte, balance int64) *testContextBuilder {
 	if len(code) == 0 {
 		tt.genesisAlloc[common.HexToAddress(addr)] = types.Account{
@@ -81,28 +110,56 @@ func (tt *testContextBuilder) withCode(addr string, code []byte, balance int64) 
 	return tt
 }
 
-// generate the code to return the given byte array (up to 32 bytes)
-func returnData(data []byte) []byte {
-	//couldn't get geth to support PUSH0 ...
-	datalen := len(data)
-	if datalen == 0 {
-		data = []byte{0}
+// generate a push opcode and its following constant value
+func push(n int) []byte {
+	if n < 0 {
+		panic("attempt to push negative")
 	}
-	if datalen > 32 {
-		panic(fmt.Errorf("data length is too big %v", data))
+	if n < 256 {
+		return createCode(vm.PUSH1, byte(n))
+	}
+	if n < 65536 {
+		return createCode(vm.PUSH2, byte(n>>8), byte(n))
+	}
+	if n < 1<<32 {
+		return createCode(vm.PUSH4, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	}
+	panic("larger number")
+}
+
+// create code to copy data into memory at the given offset
+// NOTE: if data is not in 32-byte multiples, it will override the next bytes
+// used by RETURN/REVERT
+func copyToMemory(data []byte, offset uint) []byte {
+	ret := []byte{}
+	for len(data) > 32 {
+		ret = append(ret, createCode(vm.PUSH32, data[0:32], vm.PUSH2, uint16(offset), vm.MSTORE)...)
+		data = data[32:]
+		offset = offset + 32
 	}
 
-	PUSHn := byte(int(vm.PUSH0) + datalen)
-	ret := createCode(PUSHn, data, vm.PUSH1, 0, vm.MSTORE, vm.PUSH1, 32, vm.PUSH1, 0, vm.RETURN)
+	if len(data) > 0 {
+		//push data up, as EVM is big-endian
+		v := common.RightPadBytes(data, 32)
+		ret = append(ret, createCode(vm.PUSH32, v, vm.PUSH2, uint16(offset), vm.MSTORE)...)
+	}
 	return ret
 }
 
-// create bytecode for account
-func createAccountCode() []byte {
-	magic := big.NewInt(0xbf45c166)
-	magic.Lsh(magic, 256-32)
+// revert with given data
+func revertWithData(data []byte) []byte {
+	ret := append(copyToMemory(data, 0), createCode(vm.PUSH2, uint16(len(data)), push(0), vm.REVERT)...)
+	return ret
+}
 
-	return returnData(magic.Bytes())
+// generate the code to return the given byte array (up to 32 bytes)
+func returnWithData(data []byte) []byte {
+	ret := append(copyToMemory(data, 0), createCode(vm.PUSH2, uint16(len(data)), push(0), vm.RETURN)...)
+	return ret
+}
+
+func createAccountCode() []byte {
+	return returnWithData(core.PackValidationData(core.MAGIC_VALUE_SENDER, 0, 0))
 }
 
 // create EVM code from OpCode, byte and []bytes
@@ -121,11 +178,19 @@ func createCode(items ...interface{}) []byte {
 			buffer.Write(v)
 		case int8:
 			buffer.WriteByte(byte(v))
+		case uint16:
+			buffer.Write([]byte{byte(v >> 8), byte(v)})
+		case uint32:
+			buffer.Write([]byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
 		case int:
 			if v >= 256 {
-				panic(fmt.Errorf("int defaults to int8 (byte). int16, etc: %v", v))
+				panic(fmt.Errorf("int defaults to int8 (byte). use int16, etc: %v", v))
 			}
 			buffer.WriteByte(byte(v))
+		case common.Hash:
+			buffer.Write(v.Bytes())
+		case common.Address:
+			buffer.Write(v.Bytes())
 		default:
 			// should be a compile-time error...
 			panic(fmt.Errorf("unsupported type: %T", v))
@@ -133,4 +198,17 @@ func createCode(items ...interface{}) []byte {
 	}
 
 	return buffer.Bytes()
+}
+
+func asBytes32(a int) []byte {
+	return common.LeftPadBytes(big.NewInt(int64(a)).Bytes(), 32)
+}
+
+func paymasterReturnValue(magic, validUntil, validAfter uint64, context []byte) []byte {
+	validationData := core.PackValidationData(magic, validUntil, validAfter)
+	//manual encode (bytes32 validationData, bytes context)
+	result := append(common.LeftPadBytes(validationData, 32), asBytes32(64)...)
+	result = append(result, asBytes32(len(context))...)
+	result = append(result, context...)
+	return result
 }

--- a/tests/rip7560/validation_test.go
+++ b/tests/rip7560/validation_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/tests"
+	"github.com/status-im/keycard-go/hexutils"
 	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
@@ -13,53 +14,129 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func TestValidation_OOG(t *testing.T) {
-	magic := big.NewInt(0xbf45c166)
-	magic.Lsh(magic, 256-32)
+func TestPackValidationData(t *testing.T) {
+	// --------------- after 6bytes     before 6 bytes   magic 20 bytes
+	validationData := "000000000002" + "000000000001" + "0000000000000000000000000000000000001234"
+	packed, _ := new(big.Int).SetString(validationData, 16)
+	assert.Equal(t, packed.Text(16), new(big.Int).SetBytes(core.PackValidationData(0x1234, 1, 2)).Text(16))
+}
 
-	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0), types.Rip7560AccountAbstractionTx{
+func TestUnpackValidationData(t *testing.T) {
+	packed := core.PackValidationData(0xdead, 0xcafe, 0xface)
+	magic, until, after := core.UnpackValidationData(packed)
+	assert.Equal(t, []uint64{0xdead, 0xcafe, 0xface}, []uint64{magic, until, after})
+}
+
+func TestValidationFailure_OOG(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
 		ValidationGas: uint64(1),
-		GasFeeCap:     big.NewInt(1000000000),
+		GasFeeCap:     big.NewInt(1),
 	}, "out of gas")
 }
 
-func TestValidation_ok(t *testing.T) {
-	magic := big.NewInt(0xbf45c166)
-	magic.Lsh(magic, 256-32)
-
-	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 0), types.Rip7560AccountAbstractionTx{
-		ValidationGas: uint64(1000000000),
-		GasFeeCap:     big.NewInt(1000000000),
-	}, "")
+func TestValidationFailure_no_balance(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), 1), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1),
+		GasFeeCap:     big.NewInt(1),
+	}, "insufficient funds for gas * price + value: address 0x1111111111222222222233333333334444444444 have 1 want 15001")
 }
 
-func TestValidation_account_revert(t *testing.T) {
-	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
-		createCode(vm.PUSH1, 0, vm.DUP1, vm.REVERT), 0), types.Rip7560AccountAbstractionTx{
-		ValidationGas: uint64(1000000000),
-		GasFeeCap:     big.NewInt(1000000000),
+func TestValidationFailure_sigerror(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, returnWithData(core.PackValidationData(core.MAGIC_VALUE_SIGFAIL, 0, 0)), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}, "account signature error")
+}
+
+func TestValidationFailure_validAfter(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		returnWithData(core.PackValidationData(core.MAGIC_VALUE_SENDER, 300, 200)), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}, "RIP-7560 transaction validity not reached yet")
+}
+
+func TestValidationFailure_validUntil(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		returnWithData(core.PackValidationData(core.MAGIC_VALUE_SENDER, 1, 0)), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}, "RIP-7560 transaction validity expired")
+}
+
+func TestValidation_ok(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}, "ok")
+}
+
+func TestValidation_ok_paid(t *testing.T) {
+	aatx := types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}
+	tb := newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), DEFAULT_BALANCE)
+	handleTransaction(tb, aatx, "ok")
+
+	maxCost := new(big.Int).SetUint64(aatx.ValidationGas + aatx.PaymasterGas + aatx.Gas)
+	maxCost.Mul(maxCost, aatx.GasFeeCap)
+}
+
+func TestValidationFailure_account_nonce(t *testing.T) {
+	bigNonce := new(big.Int).SetUint64(1234)
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER, createAccountCode(), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		BigNonce:      bigNonce,
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}, "nonce too high: address 0x1111111111222222222233333333334444444444, tx: 1234 state: 0")
+}
+
+func TestValidationFailure_account_revert(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		createCode(push(0), vm.DUP1, vm.REVERT), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
 	}, "execution reverted")
 }
 
-func TestValidation_account_no_return_value(t *testing.T) {
-	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER, []byte{
-		byte(vm.PUSH1), 0, byte(vm.DUP1), byte(vm.RETURN),
-	}, 0), types.Rip7560AccountAbstractionTx{
-		ValidationGas: uint64(1000000000),
-		GasFeeCap:     big.NewInt(1000000000),
+func TestValidationFailure_account_revert_with_reason(t *testing.T) {
+	// cast abi-encode 'Error(string)' hello
+	reason := hexutils.HexToBytes("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000")
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		revertWithData(reason), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}, "execution reverted")
+}
+
+func TestValidationFailure_account_wrong_return_length(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		returnWithData([]byte{1, 2, 3}), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
 	}, "invalid account return data length")
 }
 
-func TestValidation_account_wrong_return_value(t *testing.T) {
-	validatePhase(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
-		returnData(createCode(1)),
-		0), types.Rip7560AccountAbstractionTx{
-		ValidationGas: uint64(1000000000),
-		GasFeeCap:     big.NewInt(1000000000),
+func TestValidationFailure_account_no_return_value(t *testing.T) {
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		returnWithData([]byte{}), DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
+	}, "invalid account return data length")
+}
+
+func TestValidationFailure_account_wrong_return_value(t *testing.T) {
+	// create buffer of 32 byte array
+	handleValidation(newTestContextBuilder(t).withCode(DEFAULT_SENDER,
+		returnWithData(make([]byte, 32)),
+		DEFAULT_BALANCE), types.Rip7560AccountAbstractionTx{
+		ValidationGas: uint64(1000000),
+		GasFeeCap:     big.NewInt(1),
 	}, "account did not return correct MAGIC_VALUE")
 }
 
-func validatePhase(tb *testContextBuilder, aatx types.Rip7560AccountAbstractionTx, expectedErr string) {
+func handleTransaction(tb *testContextBuilder, aatx types.Rip7560AccountAbstractionTx, expectedErr string) {
 	t := tb.build()
 	if aatx.Sender == nil {
 		//pre-deployed sender account
@@ -68,12 +145,35 @@ func validatePhase(tb *testContextBuilder, aatx types.Rip7560AccountAbstractionT
 	}
 	tx := types.NewTx(&aatx)
 
-	testState := tests.MakePreState(rawdb.NewMemoryDatabase(), t.genesisAlloc, false, rawdb.HashScheme)
-	defer testState.TrieDB.Close()
+	var state = tests.MakePreState(rawdb.NewMemoryDatabase(), t.genesisAlloc, false, rawdb.HashScheme)
+	defer state.Close()
 
-	_, err := core.ApplyRip7560ValidationPhases(t.genesis.Config, t.chainContext, &common.Address{}, t.gaspool, testState.StateDB, t.genesisBlock.Header(), tx, vm.Config{})
-	// err string or empty if nil
-	errStr := ""
+	state.StateDB.SetTxContext(tx.Hash(), 0)
+	_, _, _, err := core.HandleRip7560Transactions([]*types.Transaction{tx}, 0, state.StateDB, &common.Address{}, t.genesisBlock.Header(), t.gaspool, t.genesis.Config, t.chainContext, vm.Config{})
+
+	errStr := "ok"
+	if err != nil {
+		errStr = err.Error()
+	}
+	assert.Equal(t.t, expectedErr, errStr)
+}
+
+func handleValidation(tb *testContextBuilder, aatx types.Rip7560AccountAbstractionTx, expectedErr string) {
+	t := tb.build()
+	if aatx.Sender == nil {
+		//pre-deployed sender account
+		Sender := common.HexToAddress(DEFAULT_SENDER)
+		aatx.Sender = &Sender
+	}
+	tx := types.NewTx(&aatx)
+
+	var state = tests.MakePreState(rawdb.NewMemoryDatabase(), t.genesisAlloc, false, rawdb.HashScheme)
+	defer state.Close()
+
+	state.StateDB.SetTxContext(tx.Hash(), 0)
+	_, err := core.ApplyRip7560ValidationPhases(t.genesis.Config, t.chainContext, &common.Address{}, t.gaspool, state.StateDB, t.genesisBlock.Header(), tx, vm.Config{})
+
+	errStr := "ok"
 	if err != nil {
 		errStr = err.Error()
 	}


### PR DESCRIPTION
# Description

Updated unit test codes of RIP-7560. All tests are passed except `TestValidationFailure_account_nonce` are passed, this test should be fixed in terms of RIP-7712 in the following PR.

This must be merged after #33 
