### PR TITLE
fix: revise error at processing transactions

### DIFF
--- a/core/state_processor_rip7560.go
+++ b/core/state_processor_rip7560.go
@@ -649,8 +649,8 @@ func validateAccountReturnData(data []byte, estimateFlag bool) (uint64, uint64, 
 	//todo: we check first 8 bytes of the 20-byte address (the rest is expected to be zeros)
 	if magicExpected != MAGIC_VALUE_SENDER {
 		if magicExpected == MAGIC_VALUE_SIGFAIL {
-			if !estimateFlag {
-				return 0, 0, errors.New("account signature error")
+			if estimateFlag {
+				return validAfter, validUntil, nil
 			}
 		}
 		return 0, 0, errors.New("account did not return correct MAGIC_VALUE")

--- a/core/types/transaction_signing_rip7560.go
+++ b/core/types/transaction_signing_rip7560.go
@@ -14,7 +14,7 @@ func NewRIP7560Signer(chainId *big.Int) Signer {
 func (s rip7560Signer) Sender(tx *Transaction) (common.Address, error) {
 	if tx.Type() == Rip7560Type {
 		return *tx.Rip7560TransactionData().Sender, nil
-	} else if tx.Type() != Rip7560BundleHeaderType {
+	} else if tx.Type() == Rip7560BundleHeaderType {
 		return [20]byte{}, nil
 	} else {
 		return s.londonSigner.Sender(tx)


### PR DESCRIPTION
# Description

Fixed the following 2 simple errors when processing transactions:
1. Validation step returning error when signature validation has failed when estimation.
2. `sender` at transactions that are not `TransactionType4` becomes `nil`.
